### PR TITLE
Fix/dplyr

### DIFF
--- a/tests/testthat/test-chord-mapping.R
+++ b/tests/testthat/test-chord-mapping.R
@@ -5,7 +5,7 @@ test_that("chord mapping returns as expected", {
   expect_equal(gc_name_mod("a aM b_,m7#5"), c("M", "M", "m7#5"))
 
   d <- gc_info("a", ignore_octave = FALSE)
-  expect_is(d, "tbl_df")
+  expect_s3_class(d, "tbl_df")
   expect_equal(dim(d), c(3, 12))
   d <- gc_info("ceg a#m7_5", key = "g")
   expect_true(all(d$lp_name %in% c("a#:m7_5", "a#,:m7_5")))

--- a/tests/testthat/test-phrase.R
+++ b/tests/testthat/test-phrase.R
@@ -112,7 +112,7 @@ test_that("notable returns as expected", {
 
 test_that("notification works as expected", {
   d <- do.call(rbind, lapply(x, notify))
-  expect_is(d, "tbl_df")
+  expect_s3_class(d, "tbl_df")
   expect_equal(dim(d), c(21, 3))
   expect_true(all(is.na(d$string[1:6])))
 

--- a/vignettes/tabr-prog-scales.Rmd
+++ b/vignettes/tabr-prog-scales.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 )
 library(tabr)
 library(dplyr)
-mainIntervals <- tbl_df(mainIntervals)
+mainIntervals <- as_tibble(mainIntervals)
 ```
 
 Programming with musical scales can be assisted by a collection of functions in `tabr` that check and manipulate musical scales, modes and key signatures.


### PR DESCRIPTION
Hi there, we are working on dplyr 1.2.0 and your package was flagged in our reverse dependency checks due to advancing our deprecation of `dplyr::as.tbl()` and `dplyr::tbl_df()`, both of which have been deprecated since dplyr 1.0.0 in 2020.

You'll need to update your package to use `tibble::as_tibble()` instead to stay on CRAN.

We are still working on dplyr 1.2.0, but you can consider this an (at minimum) 2 week notice!